### PR TITLE
add pre-save and post-save actions

### DIFF
--- a/bp-group-hierarchy-classes.php
+++ b/bp-group-hierarchy-classes.php
@@ -84,6 +84,9 @@ class BP_Groups_Hierarchy extends BP_Groups_Group {
 		parent::save();
 		
 		if($this->id) {
+		
+			do_action_ref_array( 'bp_group_hierarchy_before_save', array( &$this ) );
+			
 			$sql = $wpdb->prepare(
 				"UPDATE {$bp->groups->table_name} SET
 					parent_id = %d
@@ -104,6 +107,8 @@ class BP_Groups_Hierarchy extends BP_Groups_Group {
 			
 			$this->path = $this->buildPath();
 			$this->slug = $this->path;
+			
+			do_action_ref_array( 'bp_group_hierarchy_after_save', array( &$this ) );
 			
 			return true;
 		}


### PR DESCRIPTION
@ddean4040 I've added a couple of actions (based on those in `BP_Groups_Group::save()`) to `BP_Groups_Hierarchy::save()` so my plugin can monitor any updates to group hierarchies. This saves checking every plugin that's compatible with bp-group-hierarchy for hierarchy changes. It also avoids the need to hook into the 'bp_group_hierarchy_subgroup_permission_options filter' to monitor changes made when submitting bp-group-hierarchy admin forms.

Cheers, Christian
