### PR TITLE
sort by popularity descending instead of ascending

### DIFF
--- a/bp-group-hierarchy-classes.php
+++ b/bp-group-hierarchy-classes.php
@@ -295,7 +295,7 @@ class BP_Groups_Hierarchy extends BP_Groups_Group {
 				$order_sql = 'ORDER BY g.date_created DESC';
 				break;
 			case 'popular':
-				$order_sql = 'ORDER BY CONVERT(gm1.meta_value, SIGNED) ASC';
+				$order_sql = 'ORDER BY CONVERT(gm1.meta_value, SIGNED) DESC';
 				break;
 			case 'alphabetical':
 				$order_sql = 'ORDER BY g.name ASC';


### PR DESCRIPTION
When sorting by popularity the typical use case would be to sort descending, no?  
