### PR TITLE
Remove group access check if BP version = 2.1+

### DIFF
--- a/bp-group-hierarchy-loader.php
+++ b/bp-group-hierarchy-loader.php
@@ -188,45 +188,48 @@ class BP_Groups_Hierarchy_Component extends BP_Groups_Component {
 		}
 
 		// Group access control
-		if ( bp_is_groups_component() && !empty( $this->current_group ) ) {
-			if ( !$this->current_group->user_has_access ) {
+		// BuddyPress 2.1 handles group access differently, making this check no longer necessary. See https://buddypress.trac.wordpress.org/changeset/8605
+		if ( floatval( bp_get_version() ) < 2.1 ) {
+			if ( bp_is_groups_component() && !empty( $this->current_group ) ) {
+				if ( !$this->current_group->user_has_access ) {
 
-				// Hidden groups should return a 404 for non-members.
-				// Unset the current group so that you're not redirected
-				// to the default group tab
-				if ( 'hidden' == $this->current_group->status ) {
-					$this->current_group = 0;
-					$bp->is_single_item  = false;
-					bp_do_404();
-					return;
+					// Hidden groups should return a 404 for non-members.
+					// Unset the current group so that you're not redirected
+					// to the default group tab
+					if ( 'hidden' == $this->current_group->status ) {
+						$this->current_group = 0;
+						$bp->is_single_item  = false;
+						bp_do_404();
+						return;
 
-				// Skip the no_access check on home and membership request pages
-				} elseif ( ! in_array( bp_current_action(), apply_filters( 'bp_group_hierarchy_allow_anon_access', array( 'home', 'request-membership', BP_GROUP_HIERARCHY_SLUG ) ) ) ) {
-					
-					// Off-limits to this user. Throw an error and redirect to the group's home page
-					if ( is_user_logged_in() ) {
-						bp_core_no_access( array(
-							'message'  => __( 'You do not have access to this group.', 'buddypress' ),
-							'root'     => bp_get_group_permalink( $bp->groups->current_group ),
-							'redirect' => false
-						) );
+					// Skip the no_access check on home and membership request pages
+					} elseif ( ! in_array( bp_current_action(), apply_filters( 'bp_group_hierarchy_allow_anon_access', array( 'home', 'request-membership', BP_GROUP_HIERARCHY_SLUG ) ) ) ) {
+						
+						// Off-limits to this user. Throw an error and redirect to the group's home page
+						if ( is_user_logged_in() ) {
+							bp_core_no_access( array(
+								'message'  => __( 'You do not have access to this group.', 'buddypress' ),
+								'root'     => bp_get_group_permalink( $bp->groups->current_group ),
+								'redirect' => false
+							) );
 
-					// User does not have access, and does not get a message
-					} else {
-						bp_core_no_access();
+						// User does not have access, and does not get a message
+						} else {
+							bp_core_no_access();
+						}
 					}
 				}
-			}
 
-			// Protect the admin tab from non-admins
-			if ( bp_is_current_action( 'admin' ) && !bp_is_item_admin() ) {
-				bp_core_no_access( array(
-					'message'  => __( 'You are not an admin of this group.', 'buddypress' ),
-					'root'     => bp_get_group_permalink( $bp->groups->current_group ),
-					'redirect' => false
-				) );
+				// Protect the admin tab from non-admins
+				if ( bp_is_current_action( 'admin' ) && !bp_is_item_admin() ) {
+					bp_core_no_access( array(
+						'message'  => __( 'You are not an admin of this group.', 'buddypress' ),
+						'root'     => bp_get_group_permalink( $bp->groups->current_group ),
+						'redirect' => false
+					) );
+				}
 			}
-		}
+		} // End if ( floatval( bp_get_version() ) < 2.1 )
 
 		// Preconfigured group creation steps
 		$this->group_creation_steps = apply_filters( 'groups_create_group_steps', array(

--- a/bp-group-hierarchy-loader.php
+++ b/bp-group-hierarchy-loader.php
@@ -19,7 +19,7 @@ class BP_Groups_Hierarchy_Component extends BP_Groups_Component {
 	 */
 	function includes( $includes = array() ) {
 		
-		if( floatval( bp_get_version() ) >= 1.6 ) {
+		if( version_compare( bp_get_version(), 1.6, '>=' ) ) {
 		
 			$includes = array(
 				'cache',
@@ -189,7 +189,7 @@ class BP_Groups_Hierarchy_Component extends BP_Groups_Component {
 
 		// Group access control
 		// BuddyPress 2.1 handles group access differently, making this check no longer necessary. See https://buddypress.trac.wordpress.org/changeset/8605
-		if ( floatval( bp_get_version() ) < 2.1 ) {
+		if ( version_compare( bp_get_version(), 2.1, '<' ) ) {
 			if ( bp_is_groups_component() && !empty( $this->current_group ) ) {
 				if ( !$this->current_group->user_has_access ) {
 
@@ -229,7 +229,7 @@ class BP_Groups_Hierarchy_Component extends BP_Groups_Component {
 					) );
 				}
 			}
-		} // End if ( floatval( bp_get_version() ) < 2.1 )
+		} // End version_compare( bp_get_version(), 2.1, '<' )
 
 		// Preconfigured group creation steps
 		$this->group_creation_steps = apply_filters( 'groups_create_group_steps', array(


### PR DESCRIPTION
With the changes in https://buddypress.trac.wordpress.org/changeset/8605 (coming in 2.1), the groups loader
no longer needs to handle group access (which is great). This change set removes the check based on the version of BuddyPress that's being used.

Thanks for the great plugin!

@r-a-y, if you get a chance, could you look over this change, too?
