### PR TITLE
Misc fixes

### DIFF
--- a/bp-group-hierarchy-classes.php
+++ b/bp-group-hierarchy-classes.php
@@ -269,7 +269,7 @@ class BP_Groups_Hierarchy extends BP_Groups_Group {
 		}
 	}
 	
-	function get_by_parent( $parent_id, $type='active', $limit = null, $page = null, $user_id = false, $search_terms = false, $populate_extras = true ) {
+	public static function get_by_parent( $parent_id, $type='active', $limit = null, $page = null, $user_id = false, $search_terms = false, $populate_extras = true ) {
 		global $wpdb, $bp;
 		
 		$hidden_sql = '';

--- a/bp-group-hierarchy-classes.php
+++ b/bp-group-hierarchy-classes.php
@@ -311,7 +311,7 @@ class BP_Groups_Hierarchy extends BP_Groups_Group {
 		}
 		
 		if($type == 'prolific') {
-			$paged_groups = $wpdb->get_results( "SELECT g.*, (SELECT COUNT(id)FROM wp_bp_groups g2 WHERE g2.parent_id = g.id) AS child_groups, gm1.meta_value as total_member_count, gm2.meta_value as last_activity FROM {$bp->groups->table_name_groupmeta} gm1, {$bp->groups->table_name_groupmeta} gm2, {$bp->groups->table_name} g WHERE g.id = gm1.group_id AND g.id = gm2.group_id AND gm2.meta_key = 'last_activity' AND gm1.meta_key = 'total_member_count' AND g.parent_id = $parent_id {$hidden_sql} {$search_sql} {$order_sql} {$pag_sql}" );
+			$paged_groups = $wpdb->get_results( "SELECT g.*, (SELECT COUNT(id)FROM {$bp->groups->table_name} g2 WHERE g2.parent_id = g.id) AS child_groups, gm1.meta_value as total_member_count, gm2.meta_value as last_activity FROM {$bp->groups->table_name_groupmeta} gm1, {$bp->groups->table_name_groupmeta} gm2, {$bp->groups->table_name} g WHERE g.id = gm1.group_id AND g.id = gm2.group_id AND gm2.meta_key = 'last_activity' AND gm1.meta_key = 'total_member_count' AND g.parent_id = $parent_id {$hidden_sql} {$search_sql} {$order_sql} {$pag_sql}" );
 		} else {
 			$paged_groups = $wpdb->get_results( "SELECT g.*, gm1.meta_value as total_member_count, gm2.meta_value as last_activity FROM {$bp->groups->table_name_groupmeta} gm1, {$bp->groups->table_name_groupmeta} gm2, {$bp->groups->table_name} g WHERE g.id = gm1.group_id AND g.id = gm2.group_id AND gm2.meta_key = 'last_activity' AND gm1.meta_key = 'total_member_count' AND g.parent_id = $parent_id {$hidden_sql} {$search_sql} {$order_sql} {$pag_sql}" );
 		}

--- a/bp-group-hierarchy-widgets.php
+++ b/bp-group-hierarchy-widgets.php
@@ -11,7 +11,7 @@ function bp_group_hierarchy_init_widgets() {
 /*** TOPLEVEL GROUPS WIDGET *****************/
 class BP_Toplevel_Groups_Widget extends WP_Widget {
 	function bp_toplevel_groups_widget() {
-		parent::WP_Widget( false, $name = __( 'Toplevel Groups', 'bp-group-hierarchy' ), array( 'description' => __( 'A list of top-level BuddyPress groups', 'bp-group-hierarchy' ) ) );
+		parent::__construct( false, $name = __( 'Toplevel Groups', 'bp-group-hierarchy' ), array( 'description' => __( 'A list of top-level BuddyPress groups', 'bp-group-hierarchy' ) ) );
 	}
 
 	function widget($args, $instance) {

--- a/bp-group-hierarchy-widgets.php
+++ b/bp-group-hierarchy-widgets.php
@@ -119,7 +119,7 @@ class BP_Toplevel_Groups_Widget extends WP_Widget {
 class BP_Group_Navigator_Widget extends WP_Widget {
 
 	function __construct() {
-		parent::WP_Widget( false, $name = __( 'Group Navigator', 'bp-group-hierarchy' ), array('description' => __( 'A list of member groups of the current group, or top-level groups anywhere else.', 'bp-group-hierarchy' ) ) );
+		parent::__construct( false, $name = __( 'Group Navigator', 'bp-group-hierarchy' ), array('description' => __( 'A list of member groups of the current group, or top-level groups anywhere else.', 'bp-group-hierarchy' ) ) );
 	}
 	
 	function widget( $args, $instance ) {

--- a/extension.php
+++ b/extension.php
@@ -345,7 +345,7 @@ class BP_Groups_Hierarchy_Extension extends BP_Group_Extension {
 		bp_core_redirect( bp_get_group_admin_permalink( $bp->groups->current_group ) );
 	}
 	
-	function display($page = 1) {
+	function display( $group_id = null ) {
 		global $bp, $groups_template;
 		
 		$parent_template = $groups_template;


### PR DESCRIPTION
@ddean4040 I've compiled a few fixes into this PR which I hope you'll find useful. The most pressing ones seem to be:
- 0d741a1 without which no child groups are listed and
- f201132 without which a non-standard db prefix will throw errors

There are still a number of "PHP Deprecated:  Non-static method BP_Groups_Hierarchy::has_children() should not be called statically" notices being produced, but it looks like your plugin uses the method both statically and non-statically so I'm merely flagging the issue to you at this stage.
